### PR TITLE
Update types root to local types only

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -43,7 +43,7 @@
     // "baseUrl": ".",                        /* Base directory to resolve non-absolute module names. */
     // "paths": {},                           /* A series of entries which re-map imports to lookup locations relative to the 'baseUrl'. */
     // "rootDirs": [],                        /* List of root folders whose combined content represents the structure of the project at runtime. */
-    // "typeRoots": [],                       /* List of folders to include type definitions from. */
+    "typeRoots": ["./node_modules/@types/"],  /* List of folders to include type definitions from. */
     // "types": [],                           /* Type declaration files to be included in compilation. */
     // "allowSyntheticDefaultImports": true,  /* Allow default imports from modules with no default export. This does not affect code emit, just typechecking. */
     "esModuleInterop": true,                  /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */


### PR DESCRIPTION
**This PR updates:**
 `tsconfig.json`  file to restrict TypeScript from checking types outside the local types directory. Specifically, it adds the "typeRoots": ["./node_modules/@types"] configuration. 

This way the parent "../node_module", "../../node_modules:" etc. will be ignored and only local types will be taken.